### PR TITLE
Add an optional 'serde' feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,7 @@ repository = "https://github.com/1aim/vec1/"
 version = "1.0.1"
 
 [dependencies]
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
+[dev-dependencies]
+serde_json = "1.0"


### PR DESCRIPTION
Add an optional 'serde' feature, which provides `Serialize` and
`Deserialize` implementations for `Vec1`. The `Deserialize`
implementation ensures that an error is returned if the sequence is
empty.

We currently have a `Vec` inside a struct that derives `Serialize`/`Deserialize` which has run-time checks to ensure the `Vec` is non-empty. We'd love to be able to replace our use with `Vec1`, while retaining the ability to derive these traits automatically.

I investigated implementing this outside of the crate, but it created awkward ergonomics. It seems most crates choose to provide these implementations themselves behind a `serde` feature flag.