### PR TITLE
from_vec: return None

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,11 +132,11 @@ impl<T> Vec1<T> {
         Vec1( vec![ first ] )
     }
 
-    pub fn from_vec( vec: Vec<T> ) -> StdResult<Self, Vec<T>> {
+    pub fn from_vec( vec: Vec<T> ) -> Option<Self> {
         if vec.len() > 0 {
-            Ok( Vec1( vec ) )
+            Some( Vec1( vec ) )
         } else {
-            Err( vec )
+            None
         }
     }
 


### PR DESCRIPTION
The previous error case of returning the original Vec makes the API
a bit awkward.

Rust's `?` operator can't be used without implementing From on a Vec:

    Vec1::from_vec(my_vec)?

I can see how this API came to be: by moving the variable in to the
function, you can't get it back in the error case. However, because
the Vec is empty, there is no reason to want it back anyway.