### PR TITLE
implement `Default` when `T` has a default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,6 +609,15 @@ where
     }
 }
 
+impl<T> Default for Vec1<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Vec1::new(Default::default())
+    }
+}
+
 impl<T> Deref for Vec1<T> {
     type Target = [T];
 
@@ -1152,6 +1161,18 @@ mod test {
 
             assert_eq!(res, vec![2, 3, 4, 5]);
             assert_eq!(vec, vec![1]);
+        }
+
+        #[test]
+        fn deriving_default_works() {
+            #[derive(Default)]
+            struct Example {
+                field: Vec1<u8>
+            }
+
+            let example = Example::default();
+
+            assert_eq!(example.field, vec1![0]);
         }
 
         #[cfg(feature = "serde")]


### PR DESCRIPTION
Given everything in a struct has a sensible default, it's nice to be able to initialize things with `Default::default()`. This default seems like the only sensible one to me.