### PR TITLE
Use fully qualified path in macro

### DIFF
--- a/src/smallvec_v1.rs
+++ b/src/smallvec_v1.rs
@@ -44,7 +44,7 @@ macro_rules! __smallvec1_macro_v1 {
     );
     ($first:expr $(, $item:expr)* ) => ({
         let smallvec = $crate::smallvec_v1_::smallvec!($first $(, $item)*);
-        SmallVec1::try_from_smallvec(smallvec).unwrap()
+        $crate::smallvec_v1::SmallVec1::try_from_smallvec(smallvec).unwrap()
     });
 }
 


### PR DESCRIPTION
Otherwise, users have to import `SmallVec1` when using the `smallvec1` macro.

Btw thanks a lot for the smallvec support 👍 
Do you think it would be possible to make a release with it?