### PR TITLE
 Reduce rust-version to 1.71.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "vec1"
 readme = "./README.md"
 repository = "https://github.com/rustonaut/vec1/"
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.71.1"
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -756,7 +756,8 @@ where
         if N == 0 {
             Err(Size0Error)
         } else {
-            Ok(Self(value.into()))
+            // TODO: as_slice can be removed when MSRV is bumped to 1.74
+            Ok(Self(value.as_slice().into()))
         }
     }
 }
@@ -771,7 +772,8 @@ where
         if N == 0 {
             Err(Size0Error)
         } else {
-            Ok(Self(value.into()))
+            // TODO: as_slice can be removed when MSRV is bumped to 1.74
+            Ok(Self(value.as_slice().into()))
         }
     }
 }


### PR DESCRIPTION
Only a minor change is needed in order to support rustc 1.71.1. Since 1.71.1 is the version of rust currently packaged by Debian trixie (https://packages.debian.org/testing/rustc), distro packagers and others using an older compiler will benefit if that version can be supported out of the box.

For reference, the extra `as_slice` simply follows the current implementation in the stdlib

https://github.com/rust-lang/rust/blob/d84b9037541f45dc2c52a41d723265af211c0497/library/alloc/src/vec/mod.rs#L3374-L3387