### PR TITLE
Implement shared `min` and `max` functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "1.12.1"
+version = "1.13.0"
 authors = ["Philipp Korber <philipp@korber.dev>"]
 categories = ["data-structures"]
 description = "a std Vec wrapper assuring that it has at least 1 element"
@@ -41,7 +41,9 @@ smallvec-v1-write = ["std", "smallvec_v1_/write"]
 
 [dependencies]
 # Is a feature!
-serde = { version = "1.0", optional = true, features = ["derive"], default-features=false }
+serde = { version = "1.0", optional = true, features = [
+  "derive",
+], default-features = false }
 # In the future we will support smallvec v1 and v2 so if we had
 # a optional dependency called smallvec people might acidentally
 # pull it in as feature and create anoyences wrt. backward compatibility.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1366,6 +1366,24 @@ mod test {
         }
 
         #[test]
+        fn min() {
+            let a = vec1![12u8, 13, 5, 20, 9];
+            assert_eq!(a.min(), &5u8);
+
+            let b = vec1![42u8];
+            assert_eq!(b.min(), &42u8);
+        }
+
+        #[test]
+        fn max() {
+            let a = vec1![12u8, 13, 5, 20, 9];
+            assert_eq!(a.max(), &20u8);
+
+            let b = vec1![42u8];
+            assert_eq!(b.max(), &42u8);
+        }
+
+        #[test]
         fn from_vec_push() {
             assert_eq!(Vec1::from_vec_push(std::vec![], 1u8), vec1![1]);
             assert_eq!(Vec1::from_vec_push(std::vec![1, 2], 3u8), vec1![1, 2, 3]);

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -174,7 +174,6 @@ macro_rules! shared_impl {
                     self.0.first_mut().unwrap()
                 }
 
-
                 /// Truncates this vector to given length.
                 ///
                 /// # Errors
@@ -677,6 +676,30 @@ macro_rules! shared_impl {
                 #[inline(always)]
                 pub fn try_resize(&mut self, len: usize, value: $item_ty) -> Result<(), Size0Error> {
                     self.resize(len, value)
+                }
+            }
+
+            impl<$t> $name<$t>
+            where
+                $item_ty: Ord,
+                $($tb : $trait,)?
+            {
+                /// Returns a reference to the minimum element in the vector.
+                ///
+                /// As this vector always contains at least one element, this always returns a value
+                /// instead of an `Option` (unlike `Iterator::min`).
+                pub fn min(&self) -> &$item_ty {
+                    //UNWRAP_SAFE: len is at least 1
+                    self.0.iter().min().unwrap()
+                }
+
+                /// Returns a reference to the maximum element in the vector.
+                ///
+                /// As this vector always contains at least one element, this always returns a value
+                /// instead of an `Option` (unlike `Iterator::max`).
+                pub fn max(&self) -> &$item_ty {
+                    //UNWRAP_SAFE: len is at least 1
+                    self.0.iter().max().unwrap()
                 }
             }
 

--- a/src/smallvec_v1.rs
+++ b/src/smallvec_v1.rs
@@ -1021,6 +1021,24 @@ mod tests {
             .is_err());
         }
 
+        #[test]
+        fn min() {
+            let a: SmallVec1<[u8; 4]> = smallvec1![12, 13, 5, 20, 9];
+            assert_eq!(a.min(), &5);
+
+            let b: SmallVec1<[u8; 4]> = smallvec1![42];
+            assert_eq!(b.min(), &42);
+        }
+
+        #[test]
+        fn max() {
+            let a: SmallVec1<[u8; 4]> = smallvec1![12, 13, 5, 20, 9];
+            assert_eq!(a.max(), &20);
+
+            let b: SmallVec1<[u8; 4]> = smallvec1![42];
+            assert_eq!(b.max(), &42);
+        }
+
         #[cfg(feature = "serde")]
         mod serde {
             use super::super::super::*;


### PR DESCRIPTION
This PR implements shared `min` and `max` functions for both `Vec1` and `SmallVec1`.
I found this a regular use case in my codebase and I thought It'd be cool if the library itself provided these functions :)

This PR also bumps the version of the library to 1.13, is that ok?